### PR TITLE
[FIX] hr_recruitment: parse email and partner name

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -123,7 +123,6 @@ class Applicant(models.Model):
     _order = "priority desc, id desc"
     _inherit = ['mail.thread.cc', 'mail.activity.mixin', 'utm.mixin']
     _mailing_enabled = True
-    _primary_email = 'email_from'
 
     name = fields.Char("Subject / Application", required=True, help="Email subject for applications sent via email", index='trigram')
     active = fields.Boolean("Active", default=True, help="If the active field is set to false, it will allow you to hide the case without removing it.")
@@ -619,11 +618,11 @@ class Applicant(models.Model):
         stage = False
         if custom_values and 'job_id' in custom_values:
             stage = self.env['hr.job'].browse(custom_values['job_id'])._get_first_stage()
-        val = msg.get('from').split('<')[0]
+        partner_name, email_from = self.env['res.partner']._parse_partner_name(msg.get('from'))
         defaults = {
             'name': msg.get('subject') or _("No Subject"),
-            'partner_name': val,
-            'email_from': msg.get('from'),
+            'partner_name': partner_name or email_from,
+            'email_from': email_from,
             'partner_id': msg.get('author_id', False),
         }
         if msg.get('priority'):


### PR DESCRIPTION
Issue:
------
When applying for a job via an alias mail,
it is sometimes possible to get the wrong information for the applicant's name and email.

For example:
Applicant's Name: "FirstName SecondName
Email: "FirstName SecondName" <name@example.com>

Because of this, it is not possible to send an e-mail (for example, to set up a meeting)
because the latter is erroneous.

Cause:
------
Many e-mail services add the name associated with the e-mail in the header.

Example of a sent e-mail (can be retrieved with "Show original"):
```eml
MIME-Version: 1.0
Date: Wed, 21 Jun 2023 12:09:34 +0200
Message-ID: <CAHbiOmS_PHojqKMhoji9iev4I6pzuJ1=dVHgLKNh3SOS_mw7+w@mail.gmail.com>
Subject: Subject test
From: FirstName SecondName <name@example.com>
To: team-recruitment@company.com
Content-Type: multipart/alternative; boundary="000000000000f7db4305fea0f6c3"

--000000000000f7db4305fea0f6c3
Content-Type: text/plain; charset="UTF-8"

Message test

--000000000000f7db4305fea0f6c3
Content-Type: text/html; charset="UTF-8"

<div dir="ltr">Message test<br></div>

--000000000000f7db4305fea0f6c3--
```

Solution:
---------
Use `_parse_partner_name` method
to correctly parse the e-mail
and partner's name.

Note:
-----
Not add `email_from` in `_primary_email` field.
Otherwise, they will be override with the "raw" value.

opw-3347313

closes odoo/odoo#125927

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
